### PR TITLE
Add sethaxen as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @hadim
+* @sethaxen

--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ Feedstock Maintainers
 =====================
 
 * [@hadim](https://github.com/hadim/)
-
+* [@sethaxen](https://github.com/sethaxen/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - hadim
+    - sethaxen


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Ensured the license file is being packaged.

I am the maintainer of the [e3fp package](https://github.com/keiserlab/e3fp). Previously I maintained an (outdated) conda recipe at https://github.com/keiserlab/conda-recipes/tree/master/e3fp, but I am now recommending users install from conda-forge. As a result, I'd like be added as a maintainer.